### PR TITLE
fix: refund job query for full refund

### DIFF
--- a/cartridges/int_alma/cartridge/scripts/helpers/almaRefundHelper.js
+++ b/cartridges/int_alma/cartridge/scripts/helpers/almaRefundHelper.js
@@ -59,6 +59,8 @@ exports.refundPaymentForOrder = function (order, amount) {
         order.custom.almaRefundedAmount += amount ? Math.round(amount) : order.getTotalGrossPrice();
         // eslint-disable-next-line no-param-reassign
         order.custom.almaWantedRefundAmount = 0;
+        // eslint-disable-next-line no-param-reassign
+        order.custom.almaRefundType = null;
     });
 };
 

--- a/cartridges/int_alma/cartridge/scripts/steps/CheckRefund.js
+++ b/cartridges/int_alma/cartridge/scripts/steps/CheckRefund.js
@@ -22,7 +22,7 @@ function getOrdersRefunded() {
     var OrderMgr = require('dw/order/OrderMgr');
 
     return OrderMgr.searchOrders(
-        'paymentStatus = {0} and custom.almaRefundType != NULL and custom.almaWantedRefundAmount > 0 and custom.almaPaymentId != NULL', null, 2
+        'paymentStatus = {0} and (custom.almaRefundType = \'Total\' or (custom.almaRefundType = \'Partial\' and custom.almaWantedRefundAmount > 0)) and custom.almaPaymentId != NULL', null, 2
     );
 }
 


### PR DESCRIPTION
We used a query based on `almaWantedRefundAmount` to fetch refund to be made.
Unfortunately when we have a full refund, this attribute is not filled and the query doesn't fetch them

So Instead, when we refund an order, we set `almaRefundType` back to `null`, this way we only get orders to be refunded.