### PR TITLE
[Security] Enable Vulnerability scanner on PR targeting develop

### DIFF
--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -1,0 +1,31 @@
+name: Aqua
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  aqua:
+    name: Aqua scanner
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Aqua scanner
+        uses: docker://aquasec/aqua-scanner
+        with:
+          args: trivy fs --sast --reachability --scanners config,vuln,secret .
+          # To customize which severities add the following flag: --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+          # To enable SAST scanning, add: --sast
+          # To enable reachability scanning, add: --reachability
+          # To enable npm/dotnet non-lock file scanning, add: --package-json / --dotnet-proj
+        env:
+          AQUA_KEY: ${{ secrets.AQUA_KEY }}
+          AQUA_SECRET: ${{ secrets.AQUA_SECRET }}
+          GITHUB_TOKEN: ${{ github.token }}
+          AQUA_URL: https://api.eu-1.supply-chain.cloud.aquasec.com
+          CSPM_URL: https://eu-1.api.cloudsploit.com
+          TRIVY_RUN_AS_PLUGIN: "aqua"
+          # For http/https proxy configuration add env vars: HTTP_PROXY/HTTPS_PROXY, CA-CRET (path to CA certificate)


### PR DESCRIPTION
### Reason for change

To match repository's gitflow, we need to enable Aqua scans on PR targeting `develop`.

### Code changes

Modify `aqua.yml` workflow to trigger scan on PR targeting `develop`.

### How to test

No test needed.

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [x] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it


### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->

- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)