### PR TITLE
ALF-129 : ignore nodejs updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "prHourlyLimit": 20,
   "prConcurrentLimit": 20,
   "recreateWhen": "always",
-  "enabledManagers": ["github-actions", "nvm", "npm"],
+  "enabledManagers": ["github-actions", "npm"],
   "reviewers": ["team:squad-e-commerce-integrations"],
   "baseBranches": ["develop"],
   "extends": [
@@ -23,11 +23,6 @@
       "groupName": "major NPM dependencies",
       "reviewers": ["team:squad-e-commerce-integrations"],
       "draftPR": true
-    },
-    {
-      "description": "Ignore NodeJS",
-      "packageNames": ["node"],
-      "enabled": false
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,11 @@
       "groupName": "major NPM dependencies",
       "reviewers": ["team:squad-e-commerce-integrations"],
       "draftPR": true
+    },
+    {
+      "description": "Ignore NodeJS",
+      "packageNames": ["node"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Reason for change

Disable Renovate auto update of NodeJS
https://linear.app/almapay/issue/ALF-129/%F0%9F%8F%83-is-it-possible-to-block-node-version-to-v122212-on-the-repo-sfcc

⚠️ DO NOT MERGE ⚠️ 
Waiting on Node v20 tests to check if it's necessary 