### PR TITLE
feat: Set the IN_PAGE setting true by default

### DIFF
--- a/site_preference_builder/ref/system-objecttype-extensions.xml
+++ b/site_preference_builder/ref/system-objecttype-extensions.xml
@@ -81,7 +81,8 @@
                 <externally-managed-flag>false</externally-managed-flag>
             </attribute-definition>
             <attribute-definition attribute-id="ALMA_Inpage_Payment">
-                <display-name xml:lang="x-default">Enable this setting if you want in-page payments (no redirection) for all Alma payment methods.</display-name>
+                <display-name xml:lang="x-default">Activate in-page checkout</display-name>
+                <description xml:lang="x-default">Let your customers pay with Alma in a secure pop-up, without leaving your site. Learn more: https://docs.almapay.com/docs/in-page-sfcc</description>
                 <type>boolean</type>
                 <mandatory-flag>false</mandatory-flag>
                 <externally-managed-flag>false</externally-managed-flag>

--- a/site_preference_builder/ref/system-objecttype-extensions.xml
+++ b/site_preference_builder/ref/system-objecttype-extensions.xml
@@ -85,7 +85,7 @@
                 <type>boolean</type>
                 <mandatory-flag>false</mandatory-flag>
                 <externally-managed-flag>false</externally-managed-flag>
-                <default-value>false</default-value>
+                <default-value>true</default-value>
             </attribute-definition>
             <attribute-definition attribute-id="ALMA_Deferred_Capture_Activation">
                 <display-name xml:lang="x-default">Activate deferred capture</display-name>


### PR DESCRIPTION
## Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2577/[-sfcc]-set-the-in-page-setting-to-true-by-default)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We set the IN-Page setting true by default

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
